### PR TITLE
bootloader: Start building for MCUboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -3,6 +3,10 @@
 
 manifest:
   projects:
+    - name: mcuboot
+      url: https://github.com/mcu-tools/mcuboot
+      revision: aa4fa2b6e17361dd3ce16a60883059778fd147a9
+
     - name: zephyr
       url: https://github.com/zephyrproject-rtos/zephyr
       revision: v4.2.0

--- a/zephyr/dts/riscv/tinyvision/tinyclunx33_rtl.dtsi
+++ b/zephyr/dts/riscv/tinyvision/tinyclunx33_rtl.dtsi
@@ -50,14 +50,24 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 
-				boot_partition: partition@0 {
+				fpga_partition: partition@0 {
 					label = "fpga";
 					reg = <0x000000 0x100000>;
 				};
 
-				slot0_partition: partition@100000 {
-					label = "image-0";
+				boot_partition: partition@100000 {
+					label = "mcuboot"; 
 					reg = <0x100000 0x100000>;
+				};
+
+				slot0_partition: partition@200000 {
+					label = "image-0";
+					reg = <0x200000 0x100000>;
+				};
+
+				slot1_partition: partition@300000 {
+					label = "image-1"; 
+					reg = <0x200000 0x100000>;
 				};
 			};
 		};


### PR DESCRIPTION
Somewhere to keep a history of this effort. 

the following is the `mcuboot`  conf `prj.conf`

```diff
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -1,3 +1,9 @@
+CONFIG_MBEDTLS=n
+CONFIG_BOOT_SIGNATURE_TYPE_RSA=n
+CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
+
+
+# Above are the change
 CONFIG_PM=n
```
