### PR TITLE
Fix register location for spinex

### DIFF
--- a/zephyr/dts/riscv/tinyvision/tinyclunx33_rtl_1_2.dtsi
+++ b/zephyr/dts/riscv/tinyvision/tinyclunx33_rtl_1_2.dtsi
@@ -20,7 +20,7 @@
 
 		flashctrl: flash-controller@e001f000 {
 			compatible = "tinyvision,flash";
-			reg = <0xe001f000 0x30>;
+			reg = <0xe0001000 0x30>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};
@@ -57,4 +57,8 @@
 			};
 		};
 	};
+};
+
+&i2c0 {
+    rtl-version = <1>;
 };


### PR DESCRIPTION
This fixes the i2c usage for spinex and allows the firmware to boot. It also updates the flash controller address. This hasn't been tested but I'm not sure how it could work for spinex with this address being wrong